### PR TITLE
fix readme to use @types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,8 @@ TypeScript declaration file for [jsqubits](https://github.com/davidbkemp/jsqubit
 
 ### Usage
 
-Include `jsqubits.d.ts` for your project.
-
-1. Copy `jsqubits.d.ts` from cloned directory to your project,
-2. Add `./path/to/yourProject/jsqubits.d.ts` to `files` property in `tsconfig.json`.
-
-or, you can use `npm link` instead of file copy
-
 ```
-git clone git@github.com:qramana/jsqubits.d.ts.git
-cd path/to/jsqubits.d.ts
-npm link
-cd path/to/yourProject
-npm link jsqubits.d.ts
-// you can use declaration from your .ts 
+npm install @types/jsqubits --save-dev
 ```
 
 ## License

--- a/README_ja.md
+++ b/README_ja.md
@@ -11,18 +11,10 @@ jsqubits に依存しているTypeScriptプロジェクトに組み込むこと�
 ### プロジェクトへの組み込み方法
 
 jsqubits.d.ts ファイルをプロジェクトに含めてください。
-本リポジトリは npm に登録されていないため、 `npm install` で node_modules 以下にインストールすることができません。
 
 ```
-git clone git@github.com:qramana/jsqubits.d.ts.git
+npm install @types/jsqubits --save-dev
 ```
-
-以下のコマンドを実行した後、 `jsqubits.d.ts` ファイルを使いたいプロジェクト以下のディレクトリにコピーしてください。
-
-または、コピーするかわりに、 jsqubits.d.ts のディレクトリで `npm link` を実行した後、
-プロジェクトのディレクトリで `npm link jsqubits.d.ts` を実行してください。
-
-その後、tsconfig.json の files に `./node_modules/jsqubits.d.ts/jsqubits.d.ts` を追加してください。
 
 ## テスト方法
 


### PR DESCRIPTION
`@types/jsqubits` はgithubに登録されたため、今後は `npm link` の使用は不要になります。
これをREADMEに反映します。

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36805
https://www.npmjs.com/package/@types/jsqubits