### PR TITLE
Use TypeScript 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 0.1.0
+
+* fix QState#toffoli() type
+
 ## 0.0.2
 
 * fix QState#amplitude() type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsqubits.d.ts",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "unofficial jsqubits type definition",
   "main": "",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:ts": "npm run test:ts:compile && npm run test:ts:jest",
     "test:ts:compile": "tsc -p ./spec",
     "test:ts:jest": "jest",
+    "eslint": "eslint -c .eslintrc.js \"types/**/*.ts\"",
     "lint": "tslint -c tslint.json jsqubits.d.ts spec/*.ts spec/**/*.ts --project ./spec/tsconfig.json"
   },
   "repository": "https://github.com/qramana/jsqubits.d.ts",
@@ -18,9 +19,11 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.11",
+    "@typescript-eslint/eslint-plugin": "^5.10.1",
+    "@typescript-eslint/parser": "^5.10.1",
+    "eslint": "^8.1.0",
     "jest": "^24.1.0",
     "jsqubits": "~1.1.0",
-    "tslint": "^5.4.3",
-    "typescript": "^3.0.0"
+    "typescript": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test:ts": "npm run test:ts:compile && npm run test:ts:jest",
     "test:ts:compile": "tsc -p ./spec",
     "test:ts:jest": "jest",
-    "eslint": "eslint -c .eslintrc.js \"types/**/*.ts\"",
-    "lint": "tslint -c tslint.json jsqubits.d.ts spec/*.ts spec/**/*.ts --project ./spec/tsconfig.json"
+    "lint": "tslint -c tslint.json types/jsqubits.d.ts spec/**/*.ts --project ./spec/tsconfig.json"
   },
   "repository": "https://github.com/qramana/jsqubits.d.ts",
   "keywords": [
@@ -19,11 +18,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^24.0.11",
-    "@typescript-eslint/eslint-plugin": "^5.10.1",
-    "@typescript-eslint/parser": "^5.10.1",
-    "eslint": "^8.1.0",
     "jest": "^24.1.0",
     "jsqubits": "~1.1.0",
+    "tslint": "^6.1.3",
     "typescript": "^4.0.0"
   }
 }

--- a/spec/src/spec.ts
+++ b/spec/src/spec.ts
@@ -151,6 +151,7 @@ describe("QState operator", () => {
       expect(typeof state.rotateX).toBe("function");
       expect(typeof state.rotateY).toBe("function");
       expect(typeof state.rotateZ).toBe("function");
+      expect(typeof state.toffoli).toBe("function");
       done();
     });
 
@@ -266,8 +267,9 @@ describe("QState operator", () => {
     it("toffoli", (done: any) => {
       let state = jsq.jsqubits("|000>");
       expect(state.toffoli(1, 0).toString()).toBe("|000>");
+      state = jsq.jsqubits("|110>");
+      expect(state.toffoli(2, 1, 0).toString()).toBe("|111>");
       done();
-
     });
   });
 });

--- a/spec/src/spec.ts
+++ b/spec/src/spec.ts
@@ -262,5 +262,12 @@ describe("QState operator", () => {
       expect(state.x({ from: 1, to: 2 }).toString()).toBe("|110>");
       done();
     });
+
+    it("toffoli", (done: any) => {
+      let state = jsq.jsqubits("|000>");
+      expect(state.toffoli(1, 0).toString()).toBe("|000>");
+      done();
+
+    });
   });
 });

--- a/types/jsqubits.d.ts
+++ b/types/jsqubits.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/davidbkemp/jsqubits
 // Definitions by: kamakiri01 <https://github.com/kamakiri01>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// TypeScript Version: 3.0
+// TypeScript Version: 4.0
 
 export = jsqubits;
 
@@ -140,7 +140,7 @@ declare namespace jsqubits {
 // At least one control bit must be supplied to toffoli()
 type ToffoliControlQubits = [SingleQubitOperatorTargetQubits, ...SingleQubitOperatorTargetQubits[]];
 
-type ToffoliArgs = [...controlBit: ToffoliControlQubits, targetBit: SingleQubitOperatorTargetQubits];
+type ToffoliArgs = [...controlBits: ToffoliControlQubits, targetBit: SingleQubitOperatorTargetQubits];
 
 interface ExternalJSQubitsStatic {
     jsqubits: JSQubitsStatic;

--- a/types/jsqubits.d.ts
+++ b/types/jsqubits.d.ts
@@ -74,12 +74,6 @@ declare namespace jsqubits {
             controlledSwap(controlBits: undefined | SingleQubitOperatorTargetQubits, targetBit1: number, targetBit2: number): QState;
             swap(targetBit1: number, targetBit2: number): QState;
 
-            /**
-             * toffoli args is
-             * (...controlBit: SingleQubitOperatorTargetQubits[], targetBit: SingleQubitOperatorTargetQubits)
-             * but TypeScript3.4 cannot define this args.
-             * welcome Pull Request.
-             */
             toffoli(...args: ToffoliArgs): QState;
 
             controlledApplicationOfqBitOperator(

--- a/types/jsqubits.d.ts
+++ b/types/jsqubits.d.ts
@@ -80,7 +80,7 @@ declare namespace jsqubits {
              * but TypeScript3.4 cannot define this args.
              * welcome Pull Request.
              */
-            toffoli(...args: SingleQubitOperatorTargetQubits[]): QState;
+            toffoli(...args: ToffoliArgs): QState;
 
             controlledApplicationOfqBitOperator(
                 controlBits: undefined | SingleQubitOperatorTargetQubits,
@@ -136,6 +136,11 @@ declare namespace jsqubits {
         }
     }
 }
+
+// At least one control bit must be supplied to toffoli()
+type ToffoliControlQubits = [SingleQubitOperatorTargetQubits, ...SingleQubitOperatorTargetQubits[]];
+
+type ToffoliArgs = [...controlBit: ToffoliControlQubits, targetBit: SingleQubitOperatorTargetQubits];
 
 interface ExternalJSQubitsStatic {
     jsqubits: JSQubitsStatic;


### PR DESCRIPTION
Update the dependent TypeScript v3 to v4.
v4 provides a Variadic Tuple Types. It Provides the ability to define an argument variable after a spread operator.
ex: `type ToffoliArgs = [...controlBits: ToffoliControlQubits, targetBit: SingleQubitOperatorTargetQubits];`